### PR TITLE
Fix inclusion of raw-cpuid in non-x86 targets

### DIFF
--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -28,7 +28,7 @@ features = ["spin_no_std"]
 digest = { version = "0.8", features = ["dev"] }
 hex-literal = "0.1"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 raw-cpuid = "7.0.3"
 
 [features]


### PR DESCRIPTION
The current build configuration brings `raw-cpuid` for anything that is not `wasm32`, which causes havoc for, e.g., ARM.

This PR matches the same condition configuration found on `lib.rs`